### PR TITLE
Fixed default volume sharing for Boot2Docker

### DIFF
--- a/utils/aosp
+++ b/utils/aosp
@@ -9,7 +9,7 @@ set -e
 
 # Override from environment
 AOSP_IMAGE=${AOSP_IMAGE:-kylemanna/aosp}
-AOSP_VOL=${AOSP_VOL:-/vol0}
+AOSP_VOL=${AOSP_VOL:-$HOME/vol0}
 AOSP_ARGS=${AOSP_ARGS:---rm -it}
 AOSP_VOL_AOSP=${AOSP_VOL_AOSP:-$AOSP_VOL/aosp}
 AOSP_VOL_CCACHE=${AOSP_VOL_CCACHE:-$AOSP_VOL/ccache}


### PR DESCRIPTION
This fixes #3, but it makes the script more fragile as the executing user determines the default volume, -see: "$HOME/vol0"-
