### PR TITLE
Update `Dockerfile` and `utils/aosp` to work with arbitrary uid gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ COPY ssh_config /home/aosp/.ssh/config
 RUN chown aosp:aosp /home/aosp/.gitconfig && \
   chown aosp:aosp -R /home/aosp/.ssh
 
+RUN mkdir -p /tmp/ccache /aosp && \
+  chown aosp:aosp /tmp/ccache /aosp
+
 # The persistent data will be in these two directories, everything else is
 # considered to be ephemeral
 VOLUME ["/tmp/ccache", "/aosp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD https://commondatastorage.googleapis.com/git-repo-downloads/repo /usr/local/
 RUN chmod 755 /usr/local/bin/*
 
 # All builds will be done by user aosp
-RUN useradd --create-home aosp
+RUN groupadd -r aosp && useradd --create-home -g aosp aosp
 ADD gitconfig /home/aosp/.gitconfig
 ADD ssh_config /home/aosp/.ssh/config
 RUN chown aosp:aosp /home/aosp/.gitconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN chmod 755 /usr/local/bin/*
 RUN groupadd -r aosp && useradd --create-home -g aosp aosp
 COPY gitconfig /home/aosp/.gitconfig
 COPY ssh_config /home/aosp/.ssh/config
-RUN chown aosp:aosp /home/aosp/.gitconfig
+RUN chown aosp:aosp /home/aosp/.gitconfig && \
+  chown aosp:aosp -R /home/aosp/.ssh
 
 # The persistent data will be in these two directories, everything else is
 # considered to be ephemeral

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,14 +43,8 @@ RUN curl -O http://mirrors.kernel.org/ubuntu/pool/universe/o/openjdk-8/openjdk-8
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # All builds will be done by user aosp
-RUN groupadd -r aosp && useradd --create-home -g aosp aosp
-COPY gitconfig /home/aosp/.gitconfig
-COPY ssh_config /home/aosp/.ssh/config
-RUN chown aosp:aosp /home/aosp/.gitconfig && \
-  chown aosp:aosp -R /home/aosp/.ssh
-
-RUN mkdir -p /tmp/ccache /aosp && \
-  chown aosp:aosp /tmp/ccache /aosp
+COPY gitconfig /root/.gitconfig
+COPY ssh_config /root/.ssh/config
 
 # The persistent data will be in these two directories, everything else is
 # considered to be ephemeral
@@ -61,5 +55,7 @@ ENV USE_CCACHE 1
 ENV CCACHE_DIR /tmp/ccache
 
 # Work in the build directory, repo is expected to be init'd here
-USER aosp
 WORKDIR /aosp
+
+COPY utils/docker_entrypoint.sh /root/docker_entrypoint.sh
+ENTRYPOINT ["/root/docker_entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN chmod 755 /usr/local/bin/*
 
 # All builds will be done by user aosp
 RUN groupadd -r aosp && useradd --create-home -g aosp aosp
-ADD gitconfig /home/aosp/.gitconfig
-ADD ssh_config /home/aosp/.ssh/config
+COPY gitconfig /home/aosp/.gitconfig
+COPY ssh_config /home/aosp/.ssh/config
 RUN chown aosp:aosp /home/aosp/.gitconfig
 
 # The persistent data will be in these two directories, everything else is

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,25 @@ RUN apt-get update && \
 ADD https://commondatastorage.googleapis.com/git-repo-downloads/repo /usr/local/bin/
 RUN chmod 755 /usr/local/bin/*
 
+# Install latest version of JDK
+# See http://source.android.com/source/initializing.html#setting-up-a-linux-build-environment
+WORKDIR /tmp
+RUN curl -O http://mirrors.kernel.org/ubuntu/pool/universe/o/openjdk-8/openjdk-8-jre-headless_8u45-b14-1_amd64.deb && \
+    curl -O http://mirrors.kernel.org/ubuntu/pool/universe/o/openjdk-8/openjdk-8-jre_8u45-b14-1_amd64.deb && \
+    curl -O http://mirrors.kernel.org/ubuntu/pool/universe/o/openjdk-8/openjdk-8-jdk_8u45-b14-1_amd64.deb && \
+    sum=`shasum ./openjdk-8-jre-headless_8u45-b14-1_amd64.deb | awk '{ print $1 }'` && \
+    [ $sum == "e10d79f7fd1b3d011d9a4910bc3e96c3090f3306" ] || \
+      ( echo "Hash mismatch. Problem downloading openjdk-8-jre-headless" ; exit 1; ) && \
+    sum=`shasum ./openjdk-8-jre_8u45-b14-1_amd64.deb | awk '{ print $1 }'` && \
+    [ $sum == "1e083bb952fc97ab33cd46f68e82688d2b8acc34" ] || \
+      ( echo "Hash mismatch. Problem downloading openjdk-8-jre" ; exit 1; ) && \
+    sum=`shasum ./openjdk-8-jdk_8u45-b14-1_amd64.deb | awk '{ print $1 }'` && \
+    [ $sum == "772e904961a2a5c7d2d129bdbcfd5c16a0fab4bf" ] || \
+      ( echo "Hash mismatch. Problem downloading openjdk-8-jdk" ; exit 1; ) && \
+    dpkg -i *.deb && \
+    apt-get -f install && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # All builds will be done by user aosp
 RUN groupadd -r aosp && useradd --create-home -g aosp aosp
 COPY gitconfig /home/aosp/.gitconfig

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+DOCKER = docker
+IMAGE = kylemanna/aosp
+
+aosp: Dockerfile
+	$(DOCKER) build -t $(IMAGE) .
+
+all: aosp
+
+.PHONY: all

--- a/utils/aosp
+++ b/utils/aosp
@@ -12,7 +12,7 @@ set -e
 AOSP_IMAGE=${AOSP_IMAGE:-kylemanna/aosp}
 AOSP_ARGS=${AOSP_ARGS:---rm -it}
 
-AOSP_VOL=${AOSP_VOL:-/vol0}
+AOSP_VOL=${AOSP_VOL:-~/aosp-root}
 AOSP_VOL=${AOSP_VOL%/} # Trim trailing slash if needed
 AOSP_VOL_AOSP=${AOSP_VOL_AOSP:-$AOSP_VOL/aosp}
 AOSP_VOL_AOSP=${AOSP_VOL_AOSP%/} # Trim trailing slash if needed

--- a/utils/aosp
+++ b/utils/aosp
@@ -22,7 +22,7 @@ AOSP_VOL_CCACHE=${AOSP_VOL_CCACHE%/} # Trim trailing slash if needed
 # Convenience function
 function aosp_create_dir_if_needed {
   directory=$1
-  msg="Checking if $directory exists"
+  msg="aosp: Checking if $directory exists"
   echo "$msg"
   if [ ! -d "$directory" ]; then
     echo "$msg - unexistent"
@@ -37,12 +37,15 @@ function aosp_create_dir_if_needed {
 aosp_create_dir_if_needed $AOSP_VOL_AOSP
 aosp_create_dir_if_needed $AOSP_VOL_CCACHE
 
+# Set uid and gid to match host current user
+AOSP_HOST_ID_ARGS="-e USER_ID=$(id -u) -e GROUP_ID=$(id -g)"
+
 if [ -n "$SSH_AUTH_SOCK" ]; then
     SSH_AUTH_ARGS="-v $SSH_AUTH_SOCK:/tmp/ssh_auth -e SSH_AUTH_SOCK=/tmp/ssh_auth"
 fi
 
 echo ""
 
-docker run $AOSP_ARGS $SSH_AUTH_ARGS $AOSP_EXTRA_ARGS \
+docker run $AOSP_ARGS $AOSP_HOST_ID_ARGS $SSH_AUTH_ARGS $AOSP_EXTRA_ARGS \
     -v "$AOSP_VOL_AOSP:/aosp" -v "$AOSP_VOL_CCACHE:/tmp/ccache" \
     $AOSP_IMAGE $@

--- a/utils/aosp
+++ b/utils/aosp
@@ -8,11 +8,16 @@
 set -e
 
 # Override from environment
+
 AOSP_IMAGE=${AOSP_IMAGE:-kylemanna/aosp}
-AOSP_VOL=${AOSP_VOL:-/vol0}
 AOSP_ARGS=${AOSP_ARGS:---rm -it}
+
+AOSP_VOL=${AOSP_VOL:-/vol0}
+AOSP_VOL=${AOSP_VOL%/} # Trim trailing slash if needed
 AOSP_VOL_AOSP=${AOSP_VOL_AOSP:-$AOSP_VOL/aosp}
+AOSP_VOL_AOSP=${AOSP_VOL_AOSP%/} # Trim trailing slash if needed
 AOSP_VOL_CCACHE=${AOSP_VOL_CCACHE:-$AOSP_VOL/ccache}
+AOSP_VOL_CCACHE=${AOSP_VOL_CCACHE%/} # Trim trailing slash if needed
 
 if [ ! -d "$AOSP_VOL_AOSP" -o ! -d "$AOSP_VOL_CCACHE" ]; then
     sudo mkdir -p $AOSP_VOL_AOSP $AOSP_VOL_CCACHE

--- a/utils/aosp
+++ b/utils/aosp
@@ -19,14 +19,29 @@ AOSP_VOL_AOSP=${AOSP_VOL_AOSP%/} # Trim trailing slash if needed
 AOSP_VOL_CCACHE=${AOSP_VOL_CCACHE:-$AOSP_VOL/ccache}
 AOSP_VOL_CCACHE=${AOSP_VOL_CCACHE%/} # Trim trailing slash if needed
 
-if [ ! -d "$AOSP_VOL_AOSP" -o ! -d "$AOSP_VOL_CCACHE" ]; then
-    sudo mkdir -p $AOSP_VOL_AOSP $AOSP_VOL_CCACHE
-    sudo chmod 777 $AOSP_VOL_AOSP $AOSP_VOL_CCACHE
-fi
+# Convenience function
+function aosp_create_dir_if_needed {
+  directory=$1
+  msg="Checking if $directory exists"
+  echo "$msg"
+  if [ ! -d "$directory" ]; then
+    echo "$msg - unexistent"
+    msg="Creating $directory"
+    echo "$msg"
+    mkdir -p $directory
+  fi
+  echo "$msg - ok"
+}
+
+# Create AOSP_VOL_AOSP
+aosp_create_dir_if_needed $AOSP_VOL_AOSP
+aosp_create_dir_if_needed $AOSP_VOL_CCACHE
 
 if [ -n "$SSH_AUTH_SOCK" ]; then
     SSH_AUTH_ARGS="-v $SSH_AUTH_SOCK:/tmp/ssh_auth -e SSH_AUTH_SOCK=/tmp/ssh_auth"
 fi
+
+echo ""
 
 docker run $AOSP_ARGS $SSH_AUTH_ARGS $AOSP_EXTRA_ARGS \
     -v "$AOSP_VOL_AOSP:/aosp" -v "$AOSP_VOL_CCACHE:/tmp/ccache" \

--- a/utils/docker_entrypoint.sh
+++ b/utils/docker_entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# This script designed to be used a docker ENTRYPOINT "workaround" missing docker
+# feature discussed in docker/docker#7198, allow to have executable in the docker
+# container manipulating files in the shared volume owned by the USER_ID:GROUP_ID.
+#
+# It creates a user named `aosp` with selected USER_ID and GROUP_ID (or
+# 1000 if not specified).
+
+# Example:
+#
+#  docker run -ti -e USER_ID=$(id -u) -e GROUP_ID=$(id -g) imagename bash
+#
+
+# Reasonable defaults if no USER_ID/GROUP_ID environment variables are set.
+if [ -z ${USER_ID+x} ]; then USER_ID=1000; fi
+if [ -z ${GROUP_ID+x} ]; then GROUP_ID=1000; fi
+
+msg="docker_entrypoint: Creating user UID/GID [$USER_ID/$GROUP_ID]" && echo $msg
+groupadd -g $GROUP_ID -r aosp && \
+useradd -u $USER_ID --create-home -r -g aosp aosp
+echo "$msg - done"
+
+msg="docker_entrypoint: Copying .gitconfig and .ssh/config to new user home" && echo $msg
+cp /root/.gitconfig /home/aosp/.gitconfig && \
+chown aosp:aosp /home/aosp/.gitconfig && \
+mkdir -p /home/aosp/.ssh && \
+cp /root/.ssh/config /home/aosp/.ssh/config && \
+chown aosp:aosp -R /home/aosp/.ssh &&
+echo "$msg - done"
+
+msg="docker_entrypoint: Creating /tmp/ccache and /asop directory" && echo $msg
+mkdir -p /tmp/ccache /aosp
+chown aosp:aosp /tmp/ccache /aosp
+echo "$msg - done"
+
+echo ""
+
+
+# Execute command as `aosp` user
+export HOME=/home/aosp
+exec sudo -u aosp "$@"

--- a/utils/docker_entrypoint.sh
+++ b/utils/docker_entrypoint.sh
@@ -37,7 +37,12 @@ echo "$msg - done"
 
 echo ""
 
+# Default to 'bash' if no arguments are provided
+args="$@"
+if [ -z "$args" ]; then
+  args="bash"
+fi
 
 # Execute command as `aosp` user
 export HOME=/home/aosp
-exec sudo -u aosp "$@"
+exec sudo -u aosp $args


### PR DESCRIPTION
Along with including various tweaks, this PR addresses issue #9 to allow working with a current user
having an arbitrary UID/GID.

In a nutshell, it introduces the "docker_entrypoint" script that will create
a user with uid/gid matching given `USER_ID` and `GROUP_ID` (or default to
`1000` if not provided).

Fixes #9

This approach works around missing docker feature discussed in
docker/docker#7198 and allow to have executable in the docker container
manipulating files in the shared volume owned by the `USER_ID:GROUP_ID`

The utility script `aosp` has also been updated to automatically
set `USER_ID` and `GROUP_ID` to the value matching the current user
by invoking "docker run" with

```
  -e USER_ID=$(id -u) -e GROUP_ID=$(id -g)
```

Finally, the output has also been updated to be more verbose. For example:

```
$ AOSP_VOL=/home/jcfr/Projects/aosp-root/ aosp id
aosp: Checking if /home/jcfr/Projects/aosp-root/aosp exists
aosp: Checking if /home/jcfr/Projects/aosp-root/aosp exists - ok
aosp: Checking if /home/jcfr/Projects/aosp-root/ccache exists
aosp: Checking if /home/jcfr/Projects/aosp-root/ccache exists - ok

docker_entrypoint: Creating user UID/GID [1000/1000]
docker_entrypoint: Creating user UID/GID [1000/1000] - done
docker_entrypoint: Copying .gitconfig and .ssh/config to new user home
docker_entrypoint: Copying .gitconfig and .ssh/config to new user home - done
docker_entrypoint: Creating /tmp/ccache and /asop directory
docker_entrypoint: Creating /tmp/ccache and /asop directory - done

uid=1000(aosp) gid=1000(aosp) groups=1000(aosp)
```
