### PR TITLE
add USER env var

### DIFF
--- a/utils/docker_entrypoint.sh
+++ b/utils/docker_entrypoint.sh
@@ -46,3 +46,4 @@ fi
 # Execute command as `aosp` user
 export HOME=/home/aosp
 exec sudo -E -u aosp $args
+export USER=$(id -un)


### PR DESCRIPTION
android-x86 nougat build seems to fail with jack reporting an error for empty USER variable, this seems to be the solution...
haven't tested the solution yet, will update once the build has completed successfully. 